### PR TITLE
Improved sin crit rate calculation

### DIFF
--- a/src/util/algorithms.js
+++ b/src/util/algorithms.js
@@ -55,6 +55,6 @@ export const getCritRate = (player) => {
     const itemStats = player.item;
     const finalLuck = stats.luck + (data.classesWithLuck.includes(stats.class) ? itemStats.mainStatGems * data.gems.stat[itemStats.mainStatGemLvl] : 0);
     const critRate = ((finalLuck * data.critRateCoefficient[stats.class]) + (stats.critRate * 5.3)) / (data.boss[stats.dungeon].critEvasion * 2) * 0.015;
-    const additionalCritRate = (buffs.sinCritBuff ? data.buffs.sinCritBuffUptime : 0);
-    return Math.min(critRate + additionalCritRate, data.critRateCap);
+    const additionalCritRate = (buffs.sinCritBuff ? (data.buffs.sinCritBuffUptimePerMin + (60 - data.buffs.sinCritBuffUptimePerMin) * critRate) / 60 : 0);
+    return additionalCritRate ? critRate + additionalCritRate : Math.min(critRate, data.critRateCap);
 }

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -153,6 +153,6 @@ export default {
         namedEpic1HBuffPmAtk: 11 * 30 / 45,
     },
     buffs: {
-        sinCritBuffUptime: 17 / 60,
+        sinCritBuffUptimePerMin: 17,
     },
 };


### PR DESCRIPTION
Additional assassin crit rate should factor in the existing normal crit rate, and also should ignore the basic 40% crit rate cap